### PR TITLE
Add hidden form-name field to form

### DIFF
--- a/app/templates/index.hbs
+++ b/app/templates/index.hbs
@@ -7,6 +7,14 @@
   method='POST'
   data-netlify='true'
 >
+  {{!-- Because this site is statily generated with fastboot / preember, then re-hydrated with ember we need to profide this hidden form name so netlify
+        doesn't have to.
+        See:  https://www.netlify.com/blog/2017/07/20/how-to-integrate-netlifys-form-handling-in-a-react-app/?_ga=2.229357980.1617473142.1644320442-1255373435.1644320442#form-handling-with-static-site-generators
+
+        Without this the hidden form field that netlify gets skipped away when the ember ui re-hydrates and doesn't get passed along when the form is submitted
+        resulting in a 404.
+  --}}
+  <input type='hidden' name='form-name' value='survey-22' />
   <div>
     <label
       for='email'

--- a/app/templates/success.hbs
+++ b/app/templates/success.hbs
@@ -1,3 +1,3 @@
 {{page-title "Success"}}
 
-<img src="/assets/images/thank-you.png" alt="Thank you for filling out the survey" />
+<img src="./assets/images/thank-you.png" alt="Thank you for filling out the survey" />

--- a/app/templates/success.hbs
+++ b/app/templates/success.hbs
@@ -1,3 +1,3 @@
 {{page-title "Success"}}
 
-<img src="./assets/images/thank-you.png" alt="Thank you for filling out the survey" />
+<img src="/assets/images/thank-you.png" alt="Thank you for filling out the survey" />


### PR DESCRIPTION
Needed for SSR sites according to some blog posts from netlify.

Figured that was the case after finding the form worked with JS disabled and seeing the hidden form field in the actual html source, but not in the payload when js was enabled.